### PR TITLE
Add PerformanceAnalyst agent with endpoint and page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,159 @@
-# newletter-agent
+# Newsletter Agent
+
+This repository contains a prototype for an AI-powered Substack newsletter pipeline. The first implemented component is the **Data Collector** agent, which ingests metrics CSV files and past Markdown issues.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Set your `GROQ_API_KEY` in a `.env` file at the project root:
+
+```dotenv
+GROQ_API_KEY=your-api-key
+```
+
+3. Run tests:
+
+```bash
+pytest
+```
+
+### Insight Scout (Research Brief)
+
+After ingesting metrics, you can create a research brief that mixes pain-point analysis with a live search.
+
+```python
+from src.agents.insight_scout import InsightScout
+
+scout = InsightScout()
+md = scout.fetch_research_brief(
+    "./data/metrics/metrics_2025-06-01.csv",
+    "habit loops email marketing",
+)
+print(md)
+```
+
+### API & Frontend: Generate Research Brief
+
+1. **Run the FastAPI server**:
+   ```bash
+   uvicorn src.api:app --reload
+   ```
+   The server listens on `http://127.0.0.1:8000`.
+
+2. **Open the frontend page**:
+   Open `frontend/generate-research.html` in your browser (e.g., via `file://` URL).
+
+3. **Fill the form**:
+   - *Metrics CSV Path*: relative path to your CSV, e.g. `data/metrics/metrics_2025-06-01.csv`.
+   - *Search Query*: your research query.
+
+4. Click **Generate Research** to produce a Markdown brief. The output appears in the page.
+
+```example
+## Pain Points
+- **2025-05-15**: only 3.82 replies per 1k subscribers (ReplyCount=38, Subscribers=9950)
+
+## Trending Articles
+- How Habit Loops Drive Email Engagement (https://example.com/habit-loops-2025)
+- The Science of Habit Formation in Newsletters (https://news.example.org/habit-science)
+```
+
+### Outline Architect (Generate Outlines)
+
+1. **Ensure you have a Research Brief** from Insight Scout and an Issue Brief.
+2. **Run the FastAPI server** if it's not already running:
+   ```bash
+   uvicorn src.api:app --reload
+   ```
+3. **Open the frontend page**:
+   `frontend/generate-outlines.html` (via `file://` URL).
+4. Paste the Research Brief Markdown into the first textarea and enter your Issue Brief text.
+5. Click **Generate Outlines**. The page will display three Markdown outlines, each beginning with `# Outline Option`.
+
+### Draftsmith (Create Draft from Outline)
+
+1. **Ensure you have a chosen Outline** (Markdown) from Outline Architect.
+2. **Run the FastAPI server** if it's not already running:
+   ```bash
+   uvicorn src.api:app --reload
+   ```
+3. **Open the frontend page**:
+   `frontend/generate-draft.html` (via `file://` URL).
+4. Paste one of the `# Outline Option` blocks into the textarea.
+5. Click **Create Draft**.
+   The page displays a full Markdown draft beginning with `<!-- COVER_IMAGE_HOOK -->`.
+
+### Editor-in-Chief (Polish Draft)
+
+1. **Ensure you have a full draft** (Markdown) from Draftsmith or uploaded.
+2. **Run the FastAPI server** if it's not already running:
+   ```bash
+   uvicorn src.api:app --reload
+   ```
+3. **Open the frontend page**:
+   `frontend/generate-edit.html` (via `file://` URL).
+4. Paste the entire draft Markdown into the textarea.
+5. Click **Edit Draft**.
+   The page shows the polished Markdown and a revision summary under the respective headings.
+
+### Creative Director (Suggest Visuals)
+
+1. **Ensure you have a polished draft excerpt** from Editor-in-Chief.
+2. **Run the FastAPI server** if it's not already running:
+   ```bash
+   uvicorn src.api:app --reload
+   ```
+3. **Open the frontend page**:
+   `frontend/generate-visuals.html` (via `file://` URL).
+4. Paste the first few paragraphs of your polished draft into the textarea.
+5. Click **Suggest Visuals**. The page shows three lines, each containing a description and a text-to-image prompt separated by a tab.
+
+### Metrics Forecaster (Forecast Performance)
+
+1. **Ensure you have a metrics CSV** with at least 3 past issues (columns: `IssueDate`, `SubjectLine`, `OpenRate`).
+2. **Run the FastAPI server** if it's not already running:
+   ```bash
+   uvicorn src.api:app --reload
+   ```
+3. **Open the frontend page**:
+   `frontend/generate-forecast.html` (via `file://` URL).
+4. In the *Metrics CSV Path* field, enter the relative path, e.g. `data/metrics/metrics_2025-06-01.csv`.
+5. In *Subject Lines*, enter each candidate subject line on its own line.
+6. Click **Forecast Performance**. The page displays a Markdown forecast. If too little history exists, a stub forecast explains the default assumptions.
+
+### Formatter (Package for Substack)
+
+1. **Ensure you have:**
+   - A final draft Markdown file (e.g., `data/final/FinalIssue_2025-06-15.md`).
+   - A cover image (PNG or JPG), e.g., `assets/cover_2025-06-15.png`.
+2. **Run the FastAPI server** if not already running:
+   ```bash
+   uvicorn src.api:app --reload
+   ```
+3. **Open the frontend page**:
+   `frontend/generate-package.html` (via `file://` URL).
+4. Fill in all fields: draft path, cover path, title, slug, comma-separated tags, and publish datetime (ISO 8601).
+5. Click **Package for Substack**. A download link appears for the generated ZIP, e.g., `package/2025-06-15.zip`.
+   Inside the ZIP:
+   - `2025-06-15/Issue.md` (with `![Cover](images/cover.png)` at the top)
+   - `2025-06-15/images/cover.png`
+   - `2025-06-15/metadata.json`
+
+
+### Performance Analysis (Lessons Learned)
+
+1. **Ensure you have:**
+   - A forecast Markdown report from `/api/forecast-performance`.
+   - A post-send metrics CSV with columns `IssueDate`, `OpenRate`, `ClickRate`.
+2. **Run the FastAPI server**:
+   ```bash
+   uvicorn src.api:app --reload
+   ```
+3. **Open** `frontend/generate-analysis.html` in your browser.
+4. Paste the forecast Markdown and enter the CSV path.
+5. Click **Analyze Performance** to generate a Markdown summary under `## Lessons Learned`.

--- a/frontend/generate-analysis.html
+++ b/frontend/generate-analysis.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Analyze Performance</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      max-width: 700px;
+      margin: 40px auto;
+      line-height: 1.5;
+    }
+    label {
+      font-weight: bold;
+    }
+    textarea, input[type="text"] {
+      width: 100%;
+      box-sizing: border-box;
+      margin: 6px 0 12px;
+      padding: 8px;
+      font-size: 1rem;
+    }
+    button {
+      background-color: #007ACC;
+      color: white;
+      border: none;
+      padding: 10px 16px;
+      font-size: 1rem;
+      cursor: pointer;
+      border-radius: 4px;
+    }
+    button:disabled {
+      background-color: #999;
+      cursor: not-allowed;
+    }
+    #output {
+      white-space: pre-wrap;
+      background: #f5f5f5;
+      padding: 12px;
+      border-radius: 4px;
+      max-height: 400px;
+      overflow-y: auto;
+      margin-top: 12px;
+    }
+    #error {
+      color: red;
+      margin-top: 12px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Performance Analyst: Lessons Learned</h1>
+
+  <label for="forecastInput">Forecast Markdown:</label>
+  <textarea id="forecastInput" rows="8" placeholder="Paste the forecast report here..."></textarea>
+
+  <label for="actualsPath">Actuals CSV Path:</label>
+  <input type="text" id="actualsPath" placeholder="e.g., data/metrics/post_send_actuals.csv" />
+
+  <button id="analyzeBtn">Analyze Performance</button>
+
+  <div id="error"></div>
+  <h2>Analysis Output:</h2>
+  <div id="output">(Waiting for request...)</div>
+
+  <script src="js/generate-analysis.js"></script>
+</body>
+</html>

--- a/frontend/generate-draft.html
+++ b/frontend/generate-draft.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Create Draft from Outline</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      max-width: 700px;
+      margin: 40px auto;
+      line-height: 1.5;
+    }
+    label {
+      font-weight: bold;
+    }
+    textarea {
+      width: 100%;
+      box-sizing: border-box;
+      margin: 6px 0 12px;
+      padding: 8px;
+      font-size: 1rem;
+    }
+    button {
+      background-color: #007ACC;
+      color: white;
+      border: none;
+      padding: 10px 16px;
+      font-size: 1rem;
+      cursor: pointer;
+      border-radius: 4px;
+    }
+    button:disabled {
+      background-color: #999;
+      cursor: not-allowed;
+    }
+    #output {
+      white-space: pre-wrap;
+      background: #f5f5f5;
+      padding: 12px;
+      border-radius: 4px;
+      max-height: 500px;
+      overflow-y: auto;
+      margin-top: 12px;
+    }
+    #error {
+      color: red;
+      margin-top: 12px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Draftsmith: Create Draft from Outline</h1>
+
+  <label for="outlineInput">Outline (Markdown):</label>
+  <textarea id="outlineInput" rows="15" placeholder="Paste one of the Outline Option blocks here..."></textarea>
+
+  <button id="generateBtn">Create Draft</button>
+
+  <div id="error"></div>
+
+  <h2>Draft Output:</h2>
+  <div id="output">(Waiting for request...)</div>
+
+  <script src="js/generate-draft.js"></script>
+</body>
+</html>

--- a/frontend/generate-edit.html
+++ b/frontend/generate-edit.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Edit Draft</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      max-width: 700px;
+      margin: 40px auto;
+      line-height: 1.5;
+    }
+    label {
+      font-weight: bold;
+    }
+    textarea {
+      width: 100%;
+      box-sizing: border-box;
+      margin: 6px 0 12px;
+      padding: 8px;
+      font-size: 1rem;
+    }
+    button {
+      background-color: #007ACC;
+      color: white;
+      border: none;
+      padding: 10px 16px;
+      font-size: 1rem;
+      cursor: pointer;
+      border-radius: 4px;
+    }
+    button:disabled {
+      background-color: #999;
+      cursor: not-allowed;
+    }
+    #polished, #summary {
+      white-space: pre-wrap;
+      background: #f5f5f5;
+      padding: 12px;
+      border-radius: 4px;
+      max-height: 300px;
+      overflow-y: auto;
+      margin-top: 12px;
+    }
+    #error {
+      color: red;
+      margin-top: 12px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Editor-in-Chief: Polish Draft</h1>
+
+  <label for="draftInput">Draft (Markdown):</label>
+  <textarea id="draftInput" rows="15" placeholder="Paste the full draft here..."></textarea>
+
+  <button id="editBtn">Edit Draft</button>
+
+  <div id="error"></div>
+
+  <h2>Polished Draft:</h2>
+  <div id="polished">(Waiting for request...)</div>
+
+  <h2>Revision Summary:</h2>
+  <div id="summary">(Waiting for request...)</div>
+
+  <script src="js/generate-edit.js"></script>
+</body>
+</html>

--- a/frontend/generate-forecast.html
+++ b/frontend/generate-forecast.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Forecast Performance</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      max-width: 700px;
+      margin: 40px auto;
+      line-height: 1.5;
+    }
+    label {
+      font-weight: bold;
+    }
+    input[type="text"], textarea {
+      width: 100%;
+      box-sizing: border-box;
+      margin: 6px 0 12px;
+      padding: 8px;
+      font-size: 1rem;
+    }
+    button {
+      background-color: #007ACC;
+      color: white;
+      border: none;
+      padding: 10px 16px;
+      font-size: 1rem;
+      cursor: pointer;
+      border-radius: 4px;
+    }
+    button:disabled {
+      background-color: #999;
+      cursor: not-allowed;
+    }
+    #output {
+      white-space: pre-wrap;
+      background: #f5f5f5;
+      padding: 12px;
+      border-radius: 4px;
+      max-height: 400px;
+      overflow-y: auto;
+      margin-top: 12px;
+    }
+    #error {
+      color: red;
+      margin-top: 12px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Metrics Forecaster: Forecast Performance</h1>
+
+  <label for="csvPath">Metrics CSV Path:</label>
+  <input type="text" id="csvPath" placeholder="e.g., data/metrics/metrics_2025-06-01.csv" />
+
+  <label for="subjects">Subject Lines (one per line):</label>
+  <textarea id="subjects" rows="5" placeholder="Enter each subject line on its own line..."></textarea>
+
+  <button id="forecastBtn">Forecast Performance</button>
+
+  <div id="error"></div>
+
+  <h2>Forecast Output:</h2>
+  <div id="output">(Waiting for request...)</div>
+
+  <script src="js/generate-forecast.js"></script>
+</body>
+</html>

--- a/frontend/generate-outlines.html
+++ b/frontend/generate-outlines.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Generate Outlines</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      max-width: 700px;
+      margin: 40px auto;
+      line-height: 1.5;
+    }
+    label {
+      font-weight: bold;
+    }
+    textarea, input[type="text"] {
+      width: 100%;
+      box-sizing: border-box;
+      margin: 6px 0 12px;
+      padding: 8px;
+      font-size: 1rem;
+    }
+    button {
+      background-color: #007ACC;
+      color: white;
+      border: none;
+      padding: 10px 16px;
+      font-size: 1rem;
+      cursor: pointer;
+      border-radius: 4px;
+    }
+    button:disabled {
+      background-color: #999;
+      cursor: not-allowed;
+    }
+    #output {
+      white-space: pre-wrap;
+      background: #f5f5f5;
+      padding: 12px;
+      border-radius: 4px;
+      max-height: 400px;
+      overflow-y: auto;
+      margin-top: 12px;
+    }
+    #error {
+      color: red;
+      margin-top: 12px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Outline Architect: Generate Outlines</h1>
+
+  <label for="researchInput">Research Brief (Markdown):</label>
+  <textarea id="researchInput" rows="10" placeholder="Paste the full Research Brief here..."></textarea>
+
+  <label for="issueInput">Issue Brief (plain text):</label>
+  <input type="text" id="issueInput" placeholder="e.g., Topic: Habit Loops; Audience: 10k; Tone: minimal" />
+
+  <button id="generateBtn">Generate Outlines</button>
+
+  <div id="error"></div>
+
+  <h2>Outlines Output:</h2>
+  <div id="output">(Waiting for request...)</div>
+
+  <script src="js/generate-outlines.js"></script>
+</body>
+</html>

--- a/frontend/generate-package.html
+++ b/frontend/generate-package.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Package for Substack</title>
+  <style>
+    body { font-family: sans-serif; max-width: 700px; margin: 40px auto; line-height: 1.5; }
+    label { font-weight: bold; }
+    input[type="text"], input[type="file"], textarea { width: 100%; box-sizing: border-box; margin: 6px 0 12px; padding: 8px; font-size: 1rem; }
+    button { background-color: #007ACC; color: white; border: none; padding: 10px 16px; font-size: 1rem; cursor: pointer; border-radius: 4px; }
+    button:disabled { background-color: #999; cursor: not-allowed; }
+    #output { margin-top: 12px; }
+    #error { color: red; margin-top: 12px; }
+    a.download-link { display: inline-block; margin-top: 8px; color: #007ACC; text-decoration: none; }
+  </style>
+</head>
+<body>
+  <h1>Formatter: Package for Substack</h1>
+
+  <label for="draftPath">Final Draft Markdown Path:</label>
+  <input type="text" id="draftPath" placeholder="e.g., data/final/FinalIssue_2025-06-15.md" />
+
+  <label for="coverPath">Cover Image Path:</label>
+  <input type="text" id="coverPath" placeholder="e.g., assets/cover_2025-06-15.png" />
+
+  <label for="titleInput">Title:</label>
+  <input type="text" id="titleInput" placeholder="Newsletter title" />
+
+  <label for="slugInput">Slug:</label>
+  <input type="text" id="slugInput" placeholder="slug-for-article" />
+
+  <label for="tagsInput">Tags (comma-separated):</label>
+  <input type="text" id="tagsInput" placeholder="e.g., email, marketing, habit" />
+
+  <label for="publishDateInput">Publish Date/Time (ISO 8601):</label>
+  <input type="text" id="publishDateInput" placeholder="2025-07-01T09:00:00+03:00" />
+
+  <button id="packageBtn">Package for Substack</button>
+
+  <div id="error"></div>
+
+  <div id="output">
+    <h2>Package ZIP Path:</h2>
+    <div id="zipPath">(Waiting for request...)</div>
+  </div>
+
+  <script src="js/generate-package.js"></script>
+</body>
+</html>

--- a/frontend/generate-research.html
+++ b/frontend/generate-research.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Generate Research Brief</title>
+  <style>
+    body { font-family: sans-serif; max-width: 700px; margin: 40px auto; line-height: 1.5; }
+    label { font-weight: bold; }
+    input[type="text"], textarea { width: 100%; box-sizing: border-box; margin: 6px 0 12px; padding: 8px; font-size: 1rem; }
+    button { background-color: #007ACC; color: white; border: none; padding: 10px 16px; font-size: 1rem; cursor: pointer; border-radius: 4px; }
+    button:disabled { background-color: #999; cursor: not-allowed; }
+    #output { white-space: pre-wrap; background: #f5f5f5; padding: 12px; border-radius: 4px; max-height: 400px; overflow-y: auto; margin-top: 12px; }
+    #error { color: red; margin-top: 12px; }
+  </style>
+</head>
+<body>
+  <h1>Insight Scout: Generate Research Brief</h1>
+
+  <label for="csvPath">Metrics CSV Path:</label>
+  <input type="text" id="csvPath" placeholder="e.g., data/metrics/metrics_2025-06-01.csv" />
+
+  <label for="query">Search Query:</label>
+  <input type="text" id="query" placeholder="e.g., habit loops email marketing" />
+
+  <button id="generateBtn">Generate Research</button>
+
+  <div id="error"></div>
+
+  <h2>Research Brief Output:</h2>
+  <div id="output">(Waiting for request...)</div>
+
+  <script src="js/generate-research.js"></script>
+</body>
+</html>

--- a/frontend/generate-visuals.html
+++ b/frontend/generate-visuals.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Suggest Visuals</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      max-width: 700px;
+      margin: 40px auto;
+      line-height: 1.5;
+    }
+    label {
+      font-weight: bold;
+    }
+    textarea {
+      width: 100%;
+      box-sizing: border-box;
+      margin: 6px 0 12px;
+      padding: 8px;
+      font-size: 1rem;
+    }
+    button {
+      background-color: #007ACC;
+      color: white;
+      border: none;
+      padding: 10px 16px;
+      font-size: 1rem;
+      cursor: pointer;
+      border-radius: 4px;
+    }
+    button:disabled {
+      background-color: #999;
+      cursor: not-allowed;
+    }
+    #output {
+      white-space: pre-wrap;
+      background: #f5f5f5;
+      padding: 12px;
+      border-radius: 4px;
+      max-height: 300px;
+      overflow-y: auto;
+      margin-top: 12px;
+    }
+    #error {
+      color: red;
+      margin-top: 12px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Creative Director: Suggest Visuals</h1>
+
+  <label for="excerptInput">Draft Excerpt (Markdown):</label>
+  <textarea id="excerptInput" rows="10" placeholder="Paste the first few paragraphs of your polished draft here..."></textarea>
+
+  <button id="suggestBtn">Suggest Visuals</button>
+
+  <div id="error"></div>
+
+  <h2>Visual Prompts Output:</h2>
+  <div id="output">(Waiting for request...)</div>
+
+  <script src="js/generate-visuals.js"></script>
+</body>
+</html>

--- a/frontend/js/generate-analysis.js
+++ b/frontend/js/generate-analysis.js
@@ -1,0 +1,41 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const forecastInput = document.getElementById("forecastInput");
+  const actualsPath = document.getElementById("actualsPath");
+  const analyzeBtn = document.getElementById("analyzeBtn");
+  const outputDiv = document.getElementById("output");
+  const errorDiv = document.getElementById("error");
+
+  analyzeBtn.addEventListener("click", async () => {
+    errorDiv.textContent = "";
+    outputDiv.textContent = "Analyzing…";
+    analyzeBtn.disabled = true;
+
+    const forecast = forecastInput.value.trim();
+    const actuals = actualsPath.value.trim();
+    if (!forecast || !actuals) {
+      errorDiv.textContent = "Both forecast and actuals CSV path are required.";
+      outputDiv.textContent = "";
+      analyzeBtn.disabled = false;
+      return;
+    }
+
+    try {
+      const resp = await fetch("/api/analyze-performance", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ forecast_markdown: forecast, actuals_csv_path: actuals })
+      });
+      if (!resp.ok) {
+        const err = await resp.text();
+        throw new Error(`Error ${resp.status}: ${err}`);
+      }
+      const data = await resp.json();
+      outputDiv.textContent = data.analysis_markdown;
+    } catch (e) {
+      errorDiv.textContent = `Request failed: ${e.message}`;
+      outputDiv.textContent = "";
+    } finally {
+      analyzeBtn.disabled = false;
+    }
+  });
+});

--- a/frontend/js/generate-draft.js
+++ b/frontend/js/generate-draft.js
@@ -1,0 +1,41 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const outlineInput = document.getElementById("outlineInput");
+  const generateBtn = document.getElementById("generateBtn");
+  const outputDiv = document.getElementById("output");
+  const errorDiv = document.getElementById("error");
+
+  generateBtn.addEventListener("click", async () => {
+    errorDiv.textContent = "";
+    outputDiv.textContent = "Generating draft…";
+    generateBtn.disabled = true;
+
+    const outline = outlineInput.value.trim();
+    if (!outline) {
+      errorDiv.textContent = "Outline Markdown is required.";
+      outputDiv.textContent = "";
+      generateBtn.disabled = false;
+      return;
+    }
+
+    try {
+      const resp = await fetch("/api/create-draft", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ outline_markdown: outline })
+      });
+
+      if (!resp.ok) {
+        const errText = await resp.text();
+        throw new Error(`Error ${resp.status}: ${errText}`);
+      }
+
+      const data = await resp.json();
+      outputDiv.textContent = data.draft_markdown;
+    } catch (err) {
+      errorDiv.textContent = `Request failed: ${err.message}`;
+      outputDiv.textContent = "";
+    } finally {
+      generateBtn.disabled = false;
+    }
+  });
+});

--- a/frontend/js/generate-edit.js
+++ b/frontend/js/generate-edit.js
@@ -1,0 +1,46 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const draftInput = document.getElementById("draftInput");
+  const editBtn = document.getElementById("editBtn");
+  const polishedDiv = document.getElementById("polished");
+  const summaryDiv = document.getElementById("summary");
+  const errorDiv = document.getElementById("error");
+
+  editBtn.addEventListener("click", async () => {
+    errorDiv.textContent = "";
+    polishedDiv.textContent = "Editing draft…";
+    summaryDiv.textContent = "";
+    editBtn.disabled = true;
+
+    const draft = draftInput.value.trim();
+    if (!draft) {
+      errorDiv.textContent = "Draft Markdown is required.";
+      polishedDiv.textContent = "";
+      summaryDiv.textContent = "";
+      editBtn.disabled = false;
+      return;
+    }
+
+    try {
+      const resp = await fetch("/api/edit-draft", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ draft_markdown: draft })
+      });
+
+      if (!resp.ok) {
+        const errText = await resp.text();
+        throw new Error(`Error ${resp.status}: ${errText}`);
+      }
+
+      const data = await resp.json();
+      polishedDiv.textContent = data.polished_markdown;
+      summaryDiv.textContent = data.revision_summary;
+    } catch (err) {
+      errorDiv.textContent = `Request failed: ${err.message}`;
+      polishedDiv.textContent = "";
+      summaryDiv.textContent = "";
+    } finally {
+      editBtn.disabled = false;
+    }
+  });
+});

--- a/frontend/js/generate-forecast.js
+++ b/frontend/js/generate-forecast.js
@@ -1,0 +1,48 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const csvInput = document.getElementById("csvPath");
+  const subjectsInput = document.getElementById("subjects");
+  const forecastBtn = document.getElementById("forecastBtn");
+  const outputDiv = document.getElementById("output");
+  const errorDiv = document.getElementById("error");
+
+  forecastBtn.addEventListener("click", async () => {
+    errorDiv.textContent = "";
+    outputDiv.textContent = "Generating forecast…";
+    forecastBtn.disabled = true;
+
+    const csvPath = csvInput.value.trim();
+    const subjectsRaw = subjectsInput.value.trim();
+    const subjectLines = subjectsRaw
+      .split("\n")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+
+    if (!csvPath || subjectLines.length === 0) {
+      errorDiv.textContent = "Both CSV path and at least one subject line are required.";
+      outputDiv.textContent = "";
+      forecastBtn.disabled = false;
+      return;
+    }
+
+    try {
+      const resp = await fetch("/api/forecast-performance", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ csv_path: csvPath, subject_lines: subjectLines })
+      });
+
+      if (!resp.ok) {
+        const errText = await resp.text();
+        throw new Error(`Error ${resp.status}: ${errText}`);
+      }
+
+      const data = await resp.json();
+      outputDiv.textContent = data.forecast_markdown;
+    } catch (err) {
+      errorDiv.textContent = `Request failed: ${err.message}`;
+      outputDiv.textContent = "";
+    } finally {
+      forecastBtn.disabled = false;
+    }
+  });
+});

--- a/frontend/js/generate-outlines.js
+++ b/frontend/js/generate-outlines.js
@@ -1,0 +1,46 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const researchInput = document.getElementById("researchInput");
+  const issueInput = document.getElementById("issueInput");
+  const generateBtn = document.getElementById("generateBtn");
+  const outputDiv = document.getElementById("output");
+  const errorDiv = document.getElementById("error");
+
+  generateBtn.addEventListener("click", async () => {
+    errorDiv.textContent = "";
+    outputDiv.textContent = "Generating outlines…";
+    generateBtn.disabled = true;
+
+    const research = researchInput.value.trim();
+    const issue = issueInput.value.trim();
+
+    if (!research || !issue) {
+      errorDiv.textContent = "Both Research Brief and Issue Brief are required.";
+      outputDiv.textContent = "";
+      generateBtn.disabled = false;
+      return;
+    }
+
+    try {
+      const resp = await fetch("/api/generate-outlines", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({ research_brief: research, issue_brief: issue })
+      });
+
+      if (!resp.ok) {
+        const errText = await resp.text();
+        throw new Error(`Error ${resp.status}: ${errText}`);
+      }
+
+      const data = await resp.json();
+      outputDiv.textContent = data.outlines_markdown;
+    } catch (err) {
+      errorDiv.textContent = `Request failed: ${err.message}`;
+      outputDiv.textContent = "";
+    } finally {
+      generateBtn.disabled = false;
+    }
+  });
+});

--- a/frontend/js/generate-package.js
+++ b/frontend/js/generate-package.js
@@ -1,0 +1,61 @@
+// frontend/js/generate-package.js
+document.addEventListener("DOMContentLoaded", () => {
+  const draftInput = document.getElementById("draftPath");
+  const coverInput = document.getElementById("coverPath");
+  const titleInput = document.getElementById("titleInput");
+  const slugInput = document.getElementById("slugInput");
+  const tagsInput = document.getElementById("tagsInput");
+  const publishDateInput = document.getElementById("publishDateInput");
+  const packageBtn = document.getElementById("packageBtn");
+  const zipPathDiv = document.getElementById("zipPath");
+  const errorDiv = document.getElementById("error");
+
+  packageBtn.addEventListener("click", async () => {
+    errorDiv.textContent = "";
+    zipPathDiv.textContent = "Packaging…";
+    packageBtn.disabled = true;
+
+    const draftPath = draftInput.value.trim();
+    const coverPath = coverInput.value.trim();
+    const title = titleInput.value.trim();
+    const slug = slugInput.value.trim();
+    const tags = tagsInput.value.split(",").map(t => t.trim()).filter(t => t.length > 0);
+    const publishDate = publishDateInput.value.trim();
+
+    if (!draftPath || !coverPath || !title || !slug || tags.length === 0 || !publishDate) {
+      errorDiv.textContent = "All fields are required, including at least one tag.";
+      zipPathDiv.textContent = "";
+      packageBtn.disabled = false;
+      return;
+    }
+
+    try {
+      const resp = await fetch("/api/package-for-substack", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          draft_path: draftPath,
+          cover_image_path: coverPath,
+          title: title,
+          slug: slug,
+          tags: tags,
+          publish_date: publishDate
+        })
+      });
+
+      if (!resp.ok) {
+        const errText = await resp.text();
+        throw new Error(`Error ${resp.status}: ${errText}`);
+      }
+
+      const data = await resp.json();
+      const zipPath = data.package_zip_path;
+      zipPathDiv.innerHTML = `<a href="${zipPath}" class="download-link" download>Download Package ZIP</a>`;
+    } catch (err) {
+      errorDiv.textContent = `Request failed: ${err.message}`;
+      zipPathDiv.textContent = "";
+    } finally {
+      packageBtn.disabled = false;
+    }
+  });
+});

--- a/frontend/js/generate-research.js
+++ b/frontend/js/generate-research.js
@@ -1,0 +1,44 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const csvInput = document.getElementById("csvPath");
+  const queryInput = document.getElementById("query");
+  const generateBtn = document.getElementById("generateBtn");
+  const outputDiv = document.getElementById("output");
+  const errorDiv = document.getElementById("error");
+
+  generateBtn.addEventListener("click", async () => {
+    errorDiv.textContent = "";
+    outputDiv.textContent = "Generating research brief…";
+    generateBtn.disabled = true;
+
+    const csvPath = csvInput.value.trim();
+    const query = queryInput.value.trim();
+
+    if (!csvPath || !query) {
+      errorDiv.textContent = "Both CSV path and query are required.";
+      outputDiv.textContent = "";
+      generateBtn.disabled = false;
+      return;
+    }
+
+    try {
+      const resp = await fetch("/api/generate-research", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ csv_path: csvPath, query: query })
+      });
+
+      if (!resp.ok) {
+        const errText = await resp.text();
+        throw new Error(`Error ${resp.status}: ${errText}`);
+      }
+
+      const data = await resp.json();
+      outputDiv.textContent = data.research_brief;
+    } catch (err) {
+      errorDiv.textContent = `Request failed: ${err.message}`;
+      outputDiv.textContent = "";
+    } finally {
+      generateBtn.disabled = false;
+    }
+  });
+});

--- a/frontend/js/generate-visuals.js
+++ b/frontend/js/generate-visuals.js
@@ -1,0 +1,43 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const excerptInput = document.getElementById("excerptInput");
+  const suggestBtn = document.getElementById("suggestBtn");
+  const outputDiv = document.getElementById("output");
+  const errorDiv = document.getElementById("error");
+
+  suggestBtn.addEventListener("click", async () => {
+    errorDiv.textContent = "";
+    outputDiv.textContent = "Generating visual prompts…";
+    suggestBtn.disabled = true;
+
+    const excerpt = excerptInput.value.trim();
+    if (!excerpt) {
+      errorDiv.textContent = "Draft excerpt is required.";
+      outputDiv.textContent = "";
+      suggestBtn.disabled = false;
+      return;
+    }
+
+    try {
+      const resp = await fetch("/api/suggest-visuals", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({ draft_excerpt: excerpt })
+      });
+
+      if (!resp.ok) {
+        const errText = await resp.text();
+        throw new Error(`Error ${resp.status}: ${errText}`);
+      }
+
+      const data = await resp.json();
+      outputDiv.textContent = data.visual_prompts;
+    } catch (err) {
+      errorDiv.textContent = `Request failed: ${err.message}`;
+      outputDiv.textContent = "";
+    } finally {
+      suggestBtn.disabled = false;
+    }
+  });
+});

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+groq>=0.3.0
+pandas>=1.5.3
+faiss-cpu>=1.7.3
+python-dotenv>=1.0.0
+fastapi>=0.95.0
+uvicorn>=0.22.0
+pytest>=7.4.0

--- a/src/agents/creative_director.py
+++ b/src/agents/creative_director.py
@@ -1,0 +1,41 @@
+from groq import Groq
+from src.utils import get_groq_client
+
+
+class CreativeDirector:
+    """Generate cover image concepts from a draft excerpt using Groq."""
+
+    def __init__(self):
+        self.client = get_groq_client()
+
+    def suggest_visuals(self, draft_excerpt: str) -> str:
+        """Return plain-text visual prompts for the provided excerpt."""
+        if not draft_excerpt.strip():
+            raise ValueError("Draft excerpt cannot be empty.")
+
+        excerpt = draft_excerpt.strip()
+        if len(excerpt) > 1500:
+            excerpt = excerpt[:1500] + "\u2026"
+
+        prompt = (
+            "You are a creative director specialized in minimal design. "
+            "Given these first paragraphs:\n\n"
+            f"{excerpt}\n\n"
+            "Suggest 3 cover image concepts in plain text. For each concept, provide:\n"
+            "- A brief description (e.g., \"Charcoal background, yellow barbell vs. gloves\").\n"
+            "- A text-to-image prompt string suitable for DALL·E or Stable Diffusion.\n\n"
+            "Format as plain text, one concept per line, with description and prompt separated by a tab."
+        )
+
+        try:
+            response = self.client.chat.completions.create(
+                model="compound-beta-mini",
+                messages=[
+                    {"role": "system", "content": "You are a creative director."},
+                    {"role": "user", "content": prompt},
+                ],
+            )
+        except Exception as e:
+            raise RuntimeError(f"Groq API call failed: {e}")
+
+        return response.choices[0].message.content

--- a/src/agents/data_collector.py
+++ b/src/agents/data_collector.py
@@ -1,0 +1,69 @@
+import glob
+import os
+from typing import List, Dict
+
+import pandas as pd
+import numpy as np
+
+from ..utils import get_groq_client
+
+
+def ingest_metrics(csv_path: str) -> pd.DataFrame:
+    """Parse metrics CSV into DataFrame with validated columns."""
+    if not os.path.isfile(csv_path):
+        raise FileNotFoundError(f"Metrics CSV not found at {csv_path}")
+
+    df = pd.read_csv(csv_path)
+    required = {"IssueDate", "SubjectLine", "OpenRate", "ClickRate", "ReplyCount", "Subscribers"}
+    missing = required - set(df.columns)
+    if missing:
+        raise ValueError(f"Metrics CSV is missing required columns: {missing}")
+
+    df["IssueDate"] = pd.to_datetime(df["IssueDate"], format="%Y-%m-%d")
+    df["OpenRate"] = df["OpenRate"].astype(float)
+    df["ClickRate"] = df["ClickRate"].astype(float)
+    df["ReplyCount"] = df["ReplyCount"].astype(int)
+    df["Subscribers"] = df["Subscribers"].astype(int)
+
+    df = df.sort_values("IssueDate", ascending=False).reset_index(drop=True)
+    return df
+
+
+def ingest_content(markdown_dir: str) -> List[Dict[str, str]]:
+    """Load all markdown files from directory."""
+    pattern = os.path.join(markdown_dir, "*.md")
+    files = glob.glob(pattern)
+    if not files:
+        raise ValueError(f"No Markdown files found in {markdown_dir}")
+
+    docs = []
+    for path in files:
+        with open(path, "r", encoding="utf-8") as f:
+            text = f.read()
+        docs.append({"path": path, "content": text, "metadata": {"filename": os.path.basename(path)}})
+    return docs
+
+
+def compute_embeddings(documents: List[str], model: str = "llama-3.1-8b-instant") -> np.ndarray:
+    """Generate embeddings for documents using Groq via a language model."""
+    client = get_groq_client()
+    vectors = []
+    for doc in documents:
+        prompt = (
+            "Generate a fixed-length embedding vector (as a JSON array) for the following text:\n\n" + doc
+        )
+        response = client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": "You are an embedding generator."},
+                {"role": "user", "content": prompt},
+            ],
+        )
+        text = response.choices[0].message.content.strip()
+        try:
+            vector = np.array(eval(text), dtype=float)
+        except Exception as exc:
+            raise RuntimeError(f"Failed to parse embedding vector from Groq: {exc}")
+        vectors.append(vector)
+
+    return np.vstack(vectors)

--- a/src/agents/draftsmith.py
+++ b/src/agents/draftsmith.py
@@ -1,0 +1,35 @@
+from groq import Groq
+from src.utils import get_groq_client
+
+class Draftsmith:
+    """Generate a newsletter draft from an outline using Groq."""
+
+    def __init__(self):
+        self.client = get_groq_client()
+
+    def create_draft(self, outline_md: str) -> str:
+        """Return a Markdown draft. Raises ValueError on empty outline."""
+        if not outline_md.strip():
+            raise ValueError("Outline Markdown cannot be empty.")
+
+        prompt = (
+            "You are an expert newsletter writer. Using this outline:\n\n"
+            f"{outline_md}\n\n"
+            "Write a 1,200-word draft in a minimal, direct tone. "
+            "Insert a cover image placeholder <!-- COVER_IMAGE_HOOK --> at the top.\n"
+            "Include any relevant data points or examples from the outline. "
+            "Output the result as Markdown."
+        )
+
+        try:
+            response = self.client.chat.completions.create(
+                model="llama-3.3-70b-versatile",
+                messages=[
+                    {"role": "system", "content": "You are a skilled newsletter writer."},
+                    {"role": "user", "content": prompt},
+                ],
+            )
+        except Exception as exc:
+            raise RuntimeError(f"Groq API call failed: {exc}")
+
+        return response.choices[0].message.content

--- a/src/agents/editor_in_chief.py
+++ b/src/agents/editor_in_chief.py
@@ -1,0 +1,48 @@
+from groq import Groq
+import re
+from src.utils import get_groq_client
+
+class EditorInChief:
+    """Polish a draft with inline comments and summary using Groq."""
+
+    def __init__(self):
+        self.client = get_groq_client()
+
+    def edit_draft(self, draft_md: str) -> tuple[str, str]:
+        """Return polished markdown and revision summary."""
+        if not draft_md.strip():
+            raise ValueError("Draft Markdown cannot be empty.")
+
+        prompt = (
+            "You are a meticulous editor. Polish the following draft:\n\n"
+            f"{draft_md}\n\n"
+            "- Improve clarity and flow.\n"
+            "- Enforce a minimal, direct brand voice.\n"
+            "- Insert inline comments prefaced by \">> COMMENT:\" where suggestions apply.\n"
+            "- At the end, include a \"## Revision Summary\" section that lists major changes.\n\n"
+            "Output the entire result as Markdown."
+        )
+
+        try:
+            response = self.client.chat.completions.create(
+                model="llama-3.1-8b-instant",
+                messages=[
+                    {"role": "system", "content": "You are an expert editor."},
+                    {"role": "user", "content": prompt},
+                ],
+            )
+        except Exception as exc:
+            raise RuntimeError(f"Groq API call failed: {exc}")
+
+        edited_md = response.choices[0].message.content
+
+        match = re.search(r"## Revision Summary", edited_md, re.IGNORECASE)
+        if match:
+            idx = match.start()
+            polished = edited_md[:idx].rstrip()
+            summary = edited_md[idx:].strip()
+        else:
+            polished = edited_md
+            summary = ""
+
+        return polished, summary

--- a/src/agents/formatter.py
+++ b/src/agents/formatter.py
@@ -1,0 +1,84 @@
+# src/agents/formatter.py
+
+import os
+import shutil
+import json
+import zipfile
+from datetime import datetime
+from pathlib import Path
+
+class Formatter:
+    """Create a Substack-ready package from draft, cover image, and metadata."""
+
+    def __init__(self, output_root: str = "package"):
+        self.output_root = Path(output_root)
+
+    def package_for_substack(
+        self,
+        draft_path: str,
+        cover_image_path: str,
+        title: str,
+        slug: str,
+        tags: list[str],
+        publish_date: str,
+    ) -> str:
+        """Create package/YYYY-MM-DD.zip and return its path."""
+
+        draft_file = Path(draft_path)
+        if not draft_file.is_file():
+            raise FileNotFoundError(f"Draft file not found at {draft_path}")
+        cover_file = Path(cover_image_path)
+        if not cover_file.is_file():
+            raise FileNotFoundError(f"Cover image not found at {cover_image_path}")
+
+        if not title.strip():
+            raise ValueError("Title cannot be empty.")
+        if not slug.strip():
+            raise ValueError("Slug cannot be empty.")
+        if not tags:
+            raise ValueError("At least one tag is required.")
+        try:
+            datetime.fromisoformat(publish_date)
+        except Exception:
+            raise ValueError("Publish date must be in ISO 8601 format.")
+
+        date_folder = datetime.now().strftime("%Y-%m-%d")
+        pkg_dir = self.output_root / date_folder
+        images_dir = pkg_dir / "images"
+
+        try:
+            if pkg_dir.exists():
+                shutil.rmtree(pkg_dir)
+            images_dir.mkdir(parents=True)
+
+            draft_text = draft_file.read_text(encoding="utf-8")
+            issue_md = f"![Cover](images/cover.png)\n\n{draft_text}"
+            (pkg_dir / "Issue.md").write_text(issue_md, encoding="utf-8")
+
+            dest_cover = images_dir / "cover.png"
+            shutil.copy2(cover_file, dest_cover)
+
+            metadata = {
+                "title": title,
+                "slug": slug,
+                "tags": tags,
+                "publish_date": publish_date,
+            }
+            (pkg_dir / "metadata.json").write_text(
+                json.dumps(metadata, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+
+            zip_path = self.output_root / f"{date_folder}.zip"
+            with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+                for root, _, files in os.walk(pkg_dir):
+                    for file in files:
+                        fp = Path(root) / file
+                        zf.write(fp, arcname=str(fp.relative_to(self.output_root)))
+            return str(zip_path)
+        except Exception as e:
+            if pkg_dir.exists():
+                shutil.rmtree(pkg_dir)
+            zp = self.output_root / f"{date_folder}.zip"
+            if zp.exists():
+                zp.unlink()
+            raise RuntimeError(f"Packaging failed: {e}")

--- a/src/agents/insight_scout.py
+++ b/src/agents/insight_scout.py
@@ -1,0 +1,72 @@
+import os
+import pandas as pd
+
+from ..utils import get_groq_client
+
+
+class InsightScout:
+    """Combine metrics analysis with Groq compound-beta search."""
+
+    def __init__(self):
+        self.client = get_groq_client()
+
+    def _extract_pain_points(self, df: pd.DataFrame, top_n: int = 3) -> list[str]:
+        """Return a list of pain point strings based on reply engagement."""
+        df = df.copy()
+        df["RepliesPerK"] = df["ReplyCount"] / (df["Subscribers"] / 1000)
+        df_sorted = df.sort_values("RepliesPerK", ascending=True).head(top_n)
+        points = []
+        for _, row in df_sorted.iterrows():
+            date_str = row["IssueDate"].strftime("%Y-%m-%d")
+            rp = round(row["RepliesPerK"], 2)
+            points.append(
+                f"- **{date_str}**: only {rp} replies per 1k subscribers "
+                f"(ReplyCount={row['ReplyCount']}, Subscribers={row['Subscribers']})"
+            )
+        return points
+
+    def fetch_research_brief(self, csv_path: str, query: str) -> str:
+        """Return Markdown brief of pain points plus trending articles."""
+        if not os.path.isfile(csv_path):
+            raise FileNotFoundError(f"Metrics CSV not found at {csv_path}")
+
+        df = pd.read_csv(csv_path)
+        required = {"IssueDate", "SubjectLine", "OpenRate", "ClickRate", "ReplyCount", "Subscribers"}
+        missing = required - set(df.columns)
+        if missing:
+            raise ValueError(f"Metrics CSV is missing required columns: {missing}")
+
+        df["IssueDate"] = pd.to_datetime(df["IssueDate"], format="%Y-%m-%d")
+        pain_points = self._extract_pain_points(df, top_n=3)
+        pain_markdown = "## Pain Points\n" + "\n".join(pain_points)
+
+        recent = df.sort_values("IssueDate", ascending=False).head(3)
+        metrics_excerpt = "\n".join(
+            f"{row.IssueDate.strftime('%Y-%m-%d')}, {row.OpenRate}%, {row.ClickRate}%, {row.ReplyCount} replies, {row.Subscribers} subs"
+            for _, row in recent.iterrows()
+        )
+
+        prompt = (
+            "You are a data-driven newsletter researcher.\n"
+            "Here are the 3 most recent issues (Date, OpenRate%, ClickRate%, ReplyCount, Subscribers):\n\n"
+            f"{metrics_excerpt}\n\n"
+            f"(1) Based on these numbers, briefly summarize the top 3 reader pain points under '## Pain Points'.\n"
+            f"(2) Perform a web search for \"{query}\" and list 3 recent article headlines + URLs under '## Trending Articles'.\n"
+            "(3) Format the entire response as Markdown, with the two sections '## Pain Points' and '## Trending Articles'."
+        )
+
+        try:
+            response = self.client.chat.completions.create(
+                model="compound-beta",
+                messages=[
+                    {"role": "system", "content": "You are an expert research assistant."},
+                    {"role": "user", "content": prompt},
+                ],
+            )
+        except Exception as exc:
+            raise RuntimeError(f"Groq API call failed: {exc}")
+
+        content = response.choices[0].message.content
+        if "## Pain Points" not in content:
+            content = pain_markdown + "\n\n" + content
+        return content

--- a/src/agents/metrics_forecaster.py
+++ b/src/agents/metrics_forecaster.py
@@ -1,0 +1,73 @@
+import os
+from typing import List
+import pandas as pd
+
+from src.utils import get_groq_client
+
+
+class MetricsForecaster:
+    """Forecast open rates for candidate subject lines based on past metrics."""
+
+    def __init__(self):
+        self.client = get_groq_client()
+
+    def forecast(self, csv_path: str, subject_lines: List[str]) -> str:
+        """Return a Markdown forecast report given a metrics CSV and subjects."""
+        if not subject_lines or not any(s.strip() for s in subject_lines):
+            raise ValueError("At least one subject line is required.")
+
+        if not os.path.isfile(csv_path):
+            raise FileNotFoundError(f"Metrics CSV not found at {csv_path}")
+
+        df = pd.read_csv(csv_path)
+        required_cols = {"IssueDate", "SubjectLine", "OpenRate"}
+        missing = required_cols - set(df.columns)
+        if missing:
+            raise ValueError(f"Metrics CSV is missing required columns: {missing}")
+
+        df["IssueDate"] = pd.to_datetime(df["IssueDate"], format="%Y-%m-%d")
+        df_sorted = df.sort_values("IssueDate", ascending=False).reset_index(drop=True)
+        recent = df_sorted.head(5)
+
+        hist_lines = [
+            f"- {row.IssueDate.strftime('%Y-%m-%d')}: \"{row.SubjectLine}\" \u2192 {row.OpenRate}%"
+            for _, row in recent.iterrows()
+        ]
+        hist_markdown = "\n".join(hist_lines)
+
+        if len(recent) < 3:
+            stub = (
+                "## Stub Forecast\n"
+                "Insufficient historical data (fewer than 3 issues). Using generic benchmark:\n\n"
+                "- Subject Lines to test:\n"
+            )
+            for s in subject_lines:
+                stub += f"  - \"{s}\": Predicted open rate = ~15%\n"
+            stub += (
+                "\n- Recommended send date/time: Next weekday at 09:00 UTC+3\n"
+                "- Suggested segmentation: Top 20% most engaged subscribers as a test group.\n"
+            )
+            return stub
+
+        subj_md = "\n".join(f'- "{s}"' for s in subject_lines)
+        prompt = (
+            f"You are a data analyst. Here are the last {len(recent)} issues (Date: Subject \u2192 OpenRate%):\n"
+            f"{hist_markdown}\n\n"
+            f"Predict an open rate for each of these candidate subject lines:\n{subj_md}\n\n"
+            "Also recommend an optimal send date/time (weekday at 09:00 UTC+3) "
+            "and a segmentation strategy for the top 20% engaged subscribers. "
+            "Format your response in Markdown."
+        )
+
+        try:
+            response = self.client.chat.completions.create(
+                model="llama-3.1-8b-instant",
+                messages=[
+                    {"role": "system", "content": "You are a forecasting expert."},
+                    {"role": "user", "content": prompt},
+                ],
+            )
+        except Exception as e:
+            raise RuntimeError(f"Groq API call failed: {e}")
+
+        return response.choices[0].message.content

--- a/src/agents/outline_architect.py
+++ b/src/agents/outline_architect.py
@@ -1,0 +1,40 @@
+from groq import Groq
+from src.utils import get_groq_client
+
+class OutlineArchitect:
+    """Generate newsletter outlines from research and issue briefs using Groq."""
+
+    def __init__(self):
+        self.client = get_groq_client()
+
+    def generate_outlines(self, research_brief: str, issue_brief: str) -> str:
+        """Return Markdown outlines. Raises ValueError on empty input."""
+        if not research_brief.strip():
+            raise ValueError("Research brief cannot be empty.")
+        if not issue_brief.strip():
+            raise ValueError("Issue brief cannot be empty.")
+
+        prompt = (
+            "You are a professional newsletter strategist.\n\n"
+            f"Research Brief:\n{research_brief}\n\n"
+            f"Issue Brief: \"{issue_brief}\"\n\n"
+            "Generate 3 distinct outlines. Each outline must include:\n"
+            "- A heading `# Outline Option N` (where N is 1, 2, or 3).\n"
+            "- 3\u20135 section headers with 1\u20132 sentence descriptions.\n"
+            "- 3 candidate subject lines under a subheading `## Subject Line Candidates`.\n\n"
+            "Format the entire response in Markdown."
+        )
+
+        try:
+            response = self.client.chat.completions.create(
+                model="llama-3.3-70b-versatile",
+                messages=[
+                    {"role": "system", "content": "You are a newsletter outline expert."},
+                    {"role": "user", "content": prompt},
+                ],
+            )
+        except Exception as exc:
+            raise RuntimeError(f"Groq API call failed: {exc}")
+
+        outlines_md = response.choices[0].message.content
+        return outlines_md

--- a/src/agents/performance_analyst.py
+++ b/src/agents/performance_analyst.py
@@ -1,0 +1,53 @@
+import os
+import pandas as pd
+from groq import Groq
+from src.utils import get_groq_client
+
+
+class PerformanceAnalyst:
+    """Compare forecast with actual metrics and summarize lessons learned."""
+
+    def __init__(self):
+        self.client = get_groq_client()
+
+    def analyze(self, forecast_md: str, actuals_csv_path: str) -> str:
+        """Return a Markdown lessons-learned report."""
+        if not forecast_md.strip():
+            raise ValueError("Forecast Markdown cannot be empty.")
+        if not os.path.isfile(actuals_csv_path):
+            raise FileNotFoundError(f"Actuals CSV not found at {actuals_csv_path}")
+
+        df = pd.read_csv(actuals_csv_path)
+        required = {"IssueDate", "OpenRate", "ClickRate"}
+        missing = required - set(df.columns)
+        if missing:
+            raise ValueError(f"Actuals CSV missing columns: {missing}")
+
+        df["IssueDate"] = pd.to_datetime(df["IssueDate"], format="%Y-%m-%d")
+        df = df.sort_values("IssueDate", ascending=False)
+        rows = df.head(5).to_dict(orient="records")
+        actuals_lines = "\n".join(
+            f"- {r['IssueDate'].strftime('%Y-%m-%d')}: OpenRate={r['OpenRate']}%, ClickRate={r['ClickRate']}%"
+            for r in rows
+        )
+
+        prompt = (
+            "You are a performance analyst. Here is the forecast:\n\n"
+            f"{forecast_md}\n\n"
+            "And here are the actual post-send metrics (Date: OpenRate%, ClickRate%):\n"
+            f"{actuals_lines}\n\n"
+            "Compare predicted vs. actual. Under '## Lessons Learned', list 3 bullet points noting accuracy, discrepancies, and recommendations. Output as Markdown."
+        )
+
+        try:
+            resp = self.client.chat.completions.create(
+                model="llama-3.3-70b-versatile",
+                messages=[
+                    {"role": "system", "content": "You are a data-driven performance analyst."},
+                    {"role": "user", "content": prompt},
+                ],
+            )
+        except Exception as exc:
+            raise RuntimeError(f"Groq API call failed: {exc}")
+
+        return resp.choices[0].message.content

--- a/src/api.py
+++ b/src/api.py
@@ -1,0 +1,227 @@
+import os
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from src.agents.insight_scout import InsightScout
+
+app = FastAPI(title="Newsletter Agent API")
+
+
+class ResearchRequest(BaseModel):
+    csv_path: str
+    query: str
+
+
+class ResearchResponse(BaseModel):
+    research_brief: str
+
+
+@app.post("/api/generate-research", response_model=ResearchResponse)
+async def generate_research(req: ResearchRequest):
+    """Generate a research brief from metrics CSV and search query."""
+    scout = InsightScout()
+    try:
+        brief = scout.fetch_research_brief(req.csv_path, req.query)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Metrics CSV not found.")
+    except ValueError as ve:
+        raise HTTPException(status_code=400, detail=str(ve))
+    except RuntimeError as re:
+        raise HTTPException(status_code=502, detail=str(re))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Internal error: {e}")
+
+    return ResearchResponse(research_brief=brief)
+
+
+@app.get("/api/health")
+async def health_check():
+    return {"status": "ok"}
+
+from src.agents.outline_architect import OutlineArchitect
+
+class OutlineRequest(BaseModel):
+    research_brief: str
+    issue_brief: str
+
+class OutlineResponse(BaseModel):
+    outlines_markdown: str
+
+@app.post("/api/generate-outlines", response_model=OutlineResponse)
+async def generate_outlines(req: OutlineRequest):
+    """Generate newsletter outlines from research and issue briefs."""
+    architect = OutlineArchitect()
+    try:
+        md = architect.generate_outlines(req.research_brief, req.issue_brief)
+    except ValueError as ve:
+        raise HTTPException(status_code=400, detail=str(ve))
+    except RuntimeError as re:
+        raise HTTPException(status_code=502, detail=str(re))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Internal error: {e}")
+
+    return OutlineResponse(outlines_markdown=md)
+
+from src.agents.draftsmith import Draftsmith
+
+class DraftRequest(BaseModel):
+    outline_markdown: str
+
+class DraftResponse(BaseModel):
+    draft_markdown: str
+
+@app.post("/api/create-draft", response_model=DraftResponse)
+async def create_draft(req: DraftRequest):
+    """Expand an outline into a full newsletter draft."""
+    smith = Draftsmith()
+    try:
+        draft_md = smith.create_draft(req.outline_markdown)
+    except ValueError as ve:
+        raise HTTPException(status_code=400, detail=str(ve))
+    except RuntimeError as re:
+        raise HTTPException(status_code=502, detail=str(re))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Internal error: {e}")
+
+    return DraftResponse(draft_markdown=draft_md)
+
+from src.agents.editor_in_chief import EditorInChief
+
+class EditRequest(BaseModel):
+    draft_markdown: str
+
+class EditResponse(BaseModel):
+    polished_markdown: str
+    revision_summary: str
+
+@app.post("/api/edit-draft", response_model=EditResponse)
+async def edit_draft(req: EditRequest):
+    """Polish a draft and return polished content plus revision summary."""
+    editor = EditorInChief()
+    try:
+        polished, summary = editor.edit_draft(req.draft_markdown)
+    except ValueError as ve:
+        raise HTTPException(status_code=400, detail=str(ve))
+    except RuntimeError as re:
+        raise HTTPException(status_code=502, detail=str(re))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Internal error: {e}")
+
+    return EditResponse(polished_markdown=polished, revision_summary=summary)
+
+from src.agents.creative_director import CreativeDirector
+
+class VisualRequest(BaseModel):
+    draft_excerpt: str
+
+class VisualResponse(BaseModel):
+    visual_prompts: str
+
+@app.post("/api/suggest-visuals", response_model=VisualResponse)
+async def suggest_visuals(req: VisualRequest):
+    """Generate cover image concepts from a draft excerpt."""
+    director = CreativeDirector()
+    try:
+        prompts = director.suggest_visuals(req.draft_excerpt)
+    except ValueError as ve:
+        raise HTTPException(status_code=400, detail=str(ve))
+    except RuntimeError as re:
+        raise HTTPException(status_code=502, detail=str(re))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Internal error: {e}")
+
+    return VisualResponse(visual_prompts=prompts)
+
+from typing import List
+from src.agents.metrics_forecaster import MetricsForecaster
+
+class ForecastRequest(BaseModel):
+    csv_path: str
+    subject_lines: List[str]
+
+class ForecastResponse(BaseModel):
+    forecast_markdown: str
+
+@app.post("/api/forecast-performance", response_model=ForecastResponse)
+async def forecast_performance(req: ForecastRequest):
+    """Generate a performance forecast from metrics CSV and subject lines."""
+    forecaster = MetricsForecaster()
+    try:
+        md = forecaster.forecast(req.csv_path, req.subject_lines)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Metrics CSV not found.")
+    except ValueError as ve:
+        raise HTTPException(status_code=400, detail=str(ve))
+    except RuntimeError as re:
+        raise HTTPException(status_code=502, detail=str(re))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Internal error: {e}")
+
+    return ForecastResponse(forecast_markdown=md)
+
+from typing import List
+from src.agents.formatter import Formatter
+
+class PackageRequest(BaseModel):
+    draft_path: str
+    cover_image_path: str
+    title: str
+    slug: str
+    tags: List[str]
+    publish_date: str
+
+class PackageResponse(BaseModel):
+    package_zip_path: str
+
+@app.post("/api/package-for-substack", response_model=PackageResponse)
+async def package_for_substack(req: PackageRequest):
+    """Package final draft and assets into a Substack-ready ZIP."""
+    fmt = Formatter()
+    try:
+        zip_path = fmt.package_for_substack(
+            draft_path=req.draft_path,
+            cover_image_path=req.cover_image_path,
+            title=req.title,
+            slug=req.slug,
+            tags=req.tags,
+            publish_date=req.publish_date,
+        )
+    except FileNotFoundError as fnf:
+        raise HTTPException(status_code=404, detail=str(fnf))
+    except ValueError as ve:
+        raise HTTPException(status_code=400, detail=str(ve))
+    except RuntimeError as re:
+        raise HTTPException(status_code=500, detail=str(re))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Internal error: {e}")
+
+    return PackageResponse(package_zip_path=zip_path)
+
+from src.agents.performance_analyst import PerformanceAnalyst
+
+
+class AnalyzeRequest(BaseModel):
+    forecast_markdown: str
+    actuals_csv_path: str
+
+
+class AnalyzeResponse(BaseModel):
+    analysis_markdown: str
+
+
+@app.post("/api/analyze-performance", response_model=AnalyzeResponse)
+async def analyze_performance(req: AnalyzeRequest):
+    """Compare forecast vs. actual metrics and return lessons learned."""
+    analyst = PerformanceAnalyst()
+    try:
+        md = analyst.analyze(req.forecast_markdown, req.actuals_csv_path)
+    except ValueError as ve:
+        raise HTTPException(status_code=400, detail=str(ve))
+    except FileNotFoundError as fnf:
+        raise HTTPException(status_code=404, detail=str(fnf))
+    except RuntimeError as re:
+        raise HTTPException(status_code=502, detail=str(re))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Internal error: {e}")
+
+    return AnalyzeResponse(analysis_markdown=md)
+

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,10 @@
+import os
+from groq import Groq
+
+
+def get_groq_client() -> Groq:
+    """Return a Groq client using the API key from environment."""
+    api_key = os.getenv("GROQ_API_KEY")
+    if not api_key:
+        raise RuntimeError("GROQ_API_KEY not set in environment")
+    return Groq(api_key=api_key)

--- a/tests/test_content_ingestion.py
+++ b/tests/test_content_ingestion.py
@@ -1,0 +1,22 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+
+from src.agents.data_collector import ingest_content
+
+
+def test_ingest_content_success(tmp_path):
+    md_dir = tmp_path / "mds"
+    md_dir.mkdir()
+    (md_dir / "file1.md").write_text("# Title 1\nContent", encoding="utf-8")
+    (md_dir / "file2.md").write_text("# Title 2\nContent", encoding="utf-8")
+    docs = ingest_content(str(md_dir))
+    assert len(docs) == 2
+    assert docs[0]["metadata"]["filename"].endswith(".md")
+
+
+def test_ingest_content_no_files(tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(ValueError):
+        ingest_content(str(empty))

--- a/tests/test_creative_director.py
+++ b/tests/test_creative_director.py
@@ -1,0 +1,54 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from src.agents.creative_director import CreativeDirector
+
+DUMMY_EXCERPT = (
+    "# Building Habit Loops\n\n"
+    "Habit loops—composed of a cue, routine, and reward—can transform your newsletter. "
+    "They encourage subscribers to open and engage regularly."
+)
+
+
+@patch("src.agents.creative_director.get_groq_client")
+def test_suggest_visuals_success(mock_get_client):
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    dummy_output = (
+        "Charcoal background with a golden barbell: a minimal fit motif\t\"/imagine charcoal background, golden barbell, minimal style, centered\"\n"
+        "Hand-drawn habit loop diagram in pastel colors\t\"/imagine pastel hand-drawn diagram of cue-routine-reward, minimalist layout\"\n"
+        "Simple white notebook and coffee cup on a wooden table\t\"/imagine overhead shot minimal wooden table, white notebook, coffee cup, soft shadows\""
+    )
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock(message=MagicMock(content=dummy_output))]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    director = CreativeDirector()
+    result = director.suggest_visuals(DUMMY_EXCERPT)
+    lines = result.split("\n")
+    assert len(lines) == 3
+    assert "\t" in lines[0]
+    assert "barbell" in lines[0]
+
+
+@patch("src.agents.creative_director.get_groq_client")
+def test_suggest_visuals_empty_excerpt(mock_get_client):
+    director = CreativeDirector()
+    with pytest.raises(ValueError):
+        director.suggest_visuals("")
+
+
+@patch("src.agents.creative_director.get_groq_client")
+def test_suggest_visuals_api_error(mock_get_client):
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = Exception("Timeout")
+    mock_get_client.return_value = mock_client
+
+    director = CreativeDirector()
+    with pytest.raises(RuntimeError) as exc:
+        director.suggest_visuals(DUMMY_EXCERPT)
+    assert "Groq API call failed" in str(exc.value)

--- a/tests/test_data_collector.py
+++ b/tests/test_data_collector.py
@@ -1,0 +1,44 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pandas as pd
+import pytest
+
+from src.agents.data_collector import ingest_metrics
+
+
+def test_ingest_metrics_success(tmp_path):
+    csv_file = tmp_path / "metrics.csv"
+    df = pd.DataFrame({
+        "IssueDate": ["2025-06-01", "2025-05-15"],
+        "SubjectLine": ["A", "B"],
+        "OpenRate": [19.2, 18.5],
+        "ClickRate": [3.1, 2.0],
+        "ReplyCount": [10, 5],
+        "Subscribers": [1000, 1000],
+    })
+    df.to_csv(csv_file, index=False)
+    result = ingest_metrics(str(csv_file))
+    assert list(result.columns) == [
+        "IssueDate",
+        "SubjectLine",
+        "OpenRate",
+        "ClickRate",
+        "ReplyCount",
+        "Subscribers",
+    ]
+    assert result.iloc[0]["IssueDate"].strftime("%Y-%m-%d") == "2025-06-01"
+
+
+def test_ingest_metrics_missing_columns(tmp_path):
+    csv_file = tmp_path / "metrics.csv"
+    df = pd.DataFrame({
+        "IssueDate": ["2025-06-01"],
+    })
+    df.to_csv(csv_file, index=False)
+    with pytest.raises(ValueError):
+        ingest_metrics(str(csv_file))
+
+
+def test_ingest_metrics_file_not_found():
+    with pytest.raises(FileNotFoundError):
+        ingest_metrics("/nonexistent.csv")

--- a/tests/test_draftsmith.py
+++ b/tests/test_draftsmith.py
@@ -1,0 +1,54 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from src.agents.draftsmith import Draftsmith
+
+DUMMY_OUTLINE = (
+    "# Outline Option 1\n"
+    "## Section 1: Hook\n"
+    "Brief description of the hook.\n\n"
+    "## Section 2: Data\n"
+    "Include relevant data points.\n\n"
+    "## Subject Line Candidates\n"
+    "- Subject A\n"
+    "- Subject B\n"
+    "- Subject C"
+)
+
+
+@patch("src.agents.draftsmith.get_groq_client")
+def test_create_draft_success(mock_get_client):
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+    dummy = (
+        "<!-- COVER_IMAGE_HOOK -->\n"
+        "# Building Habit Loops\n\n"
+        "Body..."
+    )
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock(message=MagicMock(content=dummy))]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    smith = Draftsmith()
+    result = smith.create_draft(DUMMY_OUTLINE)
+    assert result.startswith("<!-- COVER_IMAGE_HOOK -->")
+
+
+@patch("src.agents.draftsmith.get_groq_client")
+def test_create_draft_empty_outline(mock_get_client):
+    smith = Draftsmith()
+    with pytest.raises(ValueError):
+        smith.create_draft("")
+
+
+@patch("src.agents.draftsmith.get_groq_client")
+def test_create_draft_api_error(mock_get_client):
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = Exception("boom")
+    mock_get_client.return_value = mock_client
+    smith = Draftsmith()
+    with pytest.raises(RuntimeError):
+        smith.create_draft(DUMMY_OUTLINE)

--- a/tests/test_editor_in_chief.py
+++ b/tests/test_editor_in_chief.py
@@ -1,0 +1,53 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from src.agents.editor_in_chief import EditorInChief
+
+DUMMY_DRAFT = (
+    "<!-- COVER_IMAGE_HOOK -->\n"
+    "# Building Habit Loops\n\n"
+    "Habit loops—composed of a cue, routine, and reward—can transform your newsletter. "
+    "Here is some raw text that needs clarity.\n"
+)
+
+@patch("src.agents.editor_in_chief.get_groq_client")
+def test_edit_draft_success(mock_get_client):
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+    polished_content = (
+        "<!-- COVER_IMAGE_HOOK -->\n"
+        "# Building Habit Loops\n\n"
+        "Habit loops—composed of a cue, routine, and reward—can transform your newsletter.\n"
+        ">> COMMENT: Consider simplifying this sentence.\n\n"
+        "## Revision Summary\n"
+        "- Improved clarity in opening paragraph\n"
+        "- Added inline comment"
+    )
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock(message=MagicMock(content=polished_content))]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    editor = EditorInChief()
+    polished, summary = editor.edit_draft(DUMMY_DRAFT)
+    assert ">> COMMENT:" in polished
+    assert summary.startswith("## Revision Summary")
+
+@patch("src.agents.editor_in_chief.get_groq_client")
+def test_edit_draft_empty_input(mock_get_client):
+    editor = EditorInChief()
+    with pytest.raises(ValueError):
+        editor.edit_draft("")
+
+@patch("src.agents.editor_in_chief.get_groq_client")
+def test_edit_draft_api_error(mock_get_client):
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = Exception("Timeout")
+    mock_get_client.return_value = mock_client
+
+    editor = EditorInChief()
+    with pytest.raises(RuntimeError) as exc:
+        editor.edit_draft(DUMMY_DRAFT)
+    assert "Groq API call failed" in str(exc.value)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,0 +1,81 @@
+import os
+import json
+import zipfile
+from datetime import datetime
+import pytest
+
+from src.agents.formatter import Formatter
+
+
+def write_temp_file(tmp_dir, name, content, binary=False):
+    path = os.path.join(tmp_dir, name)
+    mode = "wb" if binary else "w"
+    with open(path, mode) as f:
+        if binary:
+            f.write(content)
+        else:
+            f.write(content)
+    return path
+
+
+def test_package_success(tmp_path):
+    draft_path = write_temp_file(tmp_path, "draft.md", "# Title\nContent")
+    cover_path = write_temp_file(tmp_path, "cover.png", b"\x89PNG\r\n\x1a\n", binary=True)
+    fmt = Formatter(output_root=str(tmp_path / "pkg"))
+    zip_path = fmt.package_for_substack(
+        draft_path,
+        cover_path,
+        "Title",
+        "slug",
+        ["tag1", "tag2"],
+        "2025-07-01T09:00:00+03:00",
+    )
+    assert os.path.isfile(zip_path)
+    with zipfile.ZipFile(zip_path) as zf:
+        names = set(zf.namelist())
+        date_folder = datetime.now().strftime("%Y-%m-%d")
+        base = f"{date_folder}"
+        assert f"{base}/Issue.md" in names
+        assert f"{base}/images/cover.png" in names
+        assert f"{base}/metadata.json" in names
+        with zf.open(f"{base}/metadata.json") as f:
+            metadata = json.load(f)
+        assert metadata["title"] == "Title"
+
+
+def test_package_missing_files(tmp_path):
+    cover_path = write_temp_file(tmp_path, "cover.png", b"img", binary=True)
+    fmt = Formatter(output_root=str(tmp_path / "pkg"))
+    with pytest.raises(FileNotFoundError):
+        fmt.package_for_substack(
+            "no_draft.md",
+            cover_path,
+            "T",
+            "s",
+            ["t"],
+            "2025-07-01T09:00:00+03:00",
+        )
+    draft_path = write_temp_file(tmp_path, "draft.md", "content")
+    with pytest.raises(FileNotFoundError):
+        fmt.package_for_substack(
+            draft_path,
+            "no_cover.png",
+            "T",
+            "s",
+            ["t"],
+            "2025-07-01T09:00:00+03:00",
+        )
+
+
+def test_package_invalid_metadata(tmp_path):
+    draft_path = write_temp_file(tmp_path, "draft.md", "content")
+    cover_path = write_temp_file(tmp_path, "cover.png", b"img", binary=True)
+    fmt = Formatter(output_root=str(tmp_path / "pkg"))
+    with pytest.raises(ValueError):
+        fmt.package_for_substack(draft_path, cover_path, "", "s", ["t"], "2025-07-01T09:00:00+03:00")
+    with pytest.raises(ValueError):
+        fmt.package_for_substack(draft_path, cover_path, "T", "", ["t"], "2025-07-01T09:00:00+03:00")
+    with pytest.raises(ValueError):
+        fmt.package_for_substack(draft_path, cover_path, "T", "s", [], "2025-07-01T09:00:00+03:00")
+    with pytest.raises(ValueError):
+        fmt.package_for_substack(draft_path, cover_path, "T", "s", ["t"], "bad-date")

--- a/tests/test_insight_scout.py
+++ b/tests/test_insight_scout.py
@@ -1,0 +1,75 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pandas as pd
+import pytest
+from unittest.mock import patch, MagicMock
+
+from src.agents.insight_scout import InsightScout
+
+
+@pytest.fixture
+def temp_metrics_csv(tmp_path):
+    path = tmp_path / "metrics.csv"
+    df = pd.DataFrame({
+        "IssueDate": ["2025-06-01", "2025-05-15", "2025-05-01"],
+        "SubjectLine": ["A", "B", "C"],
+        "OpenRate": [19.2, 18.5, 17.9],
+        "ClickRate": [3.4, 2.9, 2.5],
+        "ReplyCount": [45, 38, 41],
+        "Subscribers": [10000, 9950, 9900],
+    })
+    df.to_csv(path, index=False)
+    return str(path)
+
+
+@patch("src.agents.insight_scout.get_groq_client")
+def test_extract_pain_points(mock_get_client):
+    mock_get_client.return_value = MagicMock()
+    scout = InsightScout()
+    df = pd.DataFrame({
+        "IssueDate": pd.to_datetime(["2025-06-01", "2025-05-15", "2025-05-01"]),
+        "SubjectLine": ["A", "B", "C"],
+        "OpenRate": [19.2, 18.5, 17.9],
+        "ClickRate": [3.4, 2.9, 2.5],
+        "ReplyCount": [45, 38, 41],
+        "Subscribers": [10000, 9950, 9900],
+    })
+    points = scout._extract_pain_points(df, top_n=2)
+    assert len(points) == 2
+    assert "2025-05-15" in points[0]
+
+
+@patch("src.agents.insight_scout.get_groq_client")
+def test_fetch_research_brief_success(mock_get_client, temp_metrics_csv):
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+    dummy = (
+        "## Pain Points\n- A\n- B\n\n"
+        "## Trending Articles\n- Art (https://one.com)"
+    )
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock(message=MagicMock(content=dummy))]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    scout = InsightScout()
+    result = scout.fetch_research_brief(temp_metrics_csv, "habit loops")
+    assert "## Pain Points" in result
+    assert "## Trending Articles" in result
+    assert "https://one.com" in result
+
+
+@patch("src.agents.insight_scout.get_groq_client")
+def test_fetch_research_brief_missing_csv(mock_get_client):
+    scout = InsightScout()
+    with pytest.raises(FileNotFoundError):
+        scout.fetch_research_brief("/no.csv", "x")
+
+
+@patch("src.agents.insight_scout.get_groq_client")
+def test_fetch_research_brief_missing_columns(mock_get_client, tmp_path):
+    bad = tmp_path / "bad.csv"
+    pd.DataFrame({"IssueDate": ["2025-06-01"]}).to_csv(bad, index=False)
+    scout = InsightScout()
+    with pytest.raises(ValueError):
+        scout.fetch_research_brief(str(bad), "x")

--- a/tests/test_metrics_forecaster.py
+++ b/tests/test_metrics_forecaster.py
@@ -1,0 +1,114 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pandas as pd
+import pytest
+from unittest.mock import patch, MagicMock
+
+from src.agents.metrics_forecaster import MetricsForecaster
+
+
+def write_csv(tmp_path, rows):
+    path = tmp_path / "metrics.csv"
+    pd.DataFrame(rows).to_csv(path, index=False)
+    return str(path)
+
+
+@patch("src.agents.metrics_forecaster.get_groq_client")
+def test_forecast_stub_with_insufficient_data(mock_get_client, tmp_path):
+    rows = [
+        {"IssueDate": "2025-06-01", "SubjectLine": "A", "OpenRate": 19.2},
+        {"IssueDate": "2025-05-15", "SubjectLine": "B", "OpenRate": 18.5},
+    ]
+    csv_path = write_csv(tmp_path, rows)
+    mock_get_client.return_value = MagicMock()
+    forecaster = MetricsForecaster()
+    result = forecaster.forecast(csv_path, ["Test Subject"])
+    assert "## Stub Forecast" in result
+    assert "Insufficient historical data" in result
+    assert '"Test Subject": Predicted open rate' in result
+
+
+@patch("src.agents.metrics_forecaster.get_groq_client")
+def test_forecast_file_not_found(mock_get_client):
+    mock_get_client.return_value = MagicMock()
+    forecaster = MetricsForecaster()
+    with pytest.raises(FileNotFoundError):
+        forecaster.forecast("/no.csv", ["x"])
+
+
+@patch("src.agents.metrics_forecaster.get_groq_client")
+def test_forecast_missing_columns(mock_get_client, tmp_path):
+    rows = [
+        {"IssueDate": "2025-06-01", "SubjectLine": "A"},
+        {"IssueDate": "2025-05-15", "SubjectLine": "B"},
+        {"IssueDate": "2025-05-01", "SubjectLine": "C"},
+    ]
+    csv_path = write_csv(tmp_path, rows)
+    mock_get_client.return_value = MagicMock()
+    forecaster = MetricsForecaster()
+    with pytest.raises(ValueError) as exc:
+        forecaster.forecast(csv_path, ["S"])
+    assert "missing required columns" in str(exc.value)
+
+
+@patch("src.agents.metrics_forecaster.get_groq_client")
+def test_forecast_empty_subjects(mock_get_client, tmp_path):
+    rows = [
+        {"IssueDate": "2025-06-01", "SubjectLine": "A", "OpenRate": 19.2},
+        {"IssueDate": "2025-05-15", "SubjectLine": "B", "OpenRate": 18.5},
+        {"IssueDate": "2025-05-01", "SubjectLine": "C", "OpenRate": 17.9},
+    ]
+    csv_path = write_csv(tmp_path, rows)
+    mock_get_client.return_value = MagicMock()
+    forecaster = MetricsForecaster()
+    with pytest.raises(ValueError):
+        forecaster.forecast(csv_path, ["", "   "])
+
+
+@patch("src.agents.metrics_forecaster.get_groq_client")
+def test_forecast_success(mock_get_client, tmp_path):
+    rows = [
+        {"IssueDate": "2025-06-01", "SubjectLine": "A", "OpenRate": 19.2},
+        {"IssueDate": "2025-05-15", "SubjectLine": "B", "OpenRate": 18.5},
+        {"IssueDate": "2025-05-01", "SubjectLine": "C", "OpenRate": 17.9},
+        {"IssueDate": "2025-04-15", "SubjectLine": "D", "OpenRate": 17.0},
+    ]
+    csv_path = write_csv(tmp_path, rows)
+
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+    dummy_output = (
+        "## Forecast\n"
+        "- \"Subj\": Predicted open rate = 20%\n\n"
+        "Recommended send date/time: 2025-07-02 at 09:00 UTC+3\n\n"
+        "Suggested segmentation: Top 20% engaged subscribers.\n"
+    )
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock(message=MagicMock(content=dummy_output))]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    forecaster = MetricsForecaster()
+    result = forecaster.forecast(csv_path, ["Subj"])
+    assert "## Forecast" in result
+    assert "Predicted open rate" in result
+    assert "Recommended send date/time" in result
+
+
+@patch("src.agents.metrics_forecaster.get_groq_client")
+def test_forecast_api_error(mock_get_client, tmp_path):
+    rows = [
+        {"IssueDate": "2025-06-01", "SubjectLine": "A", "OpenRate": 19.2},
+        {"IssueDate": "2025-05-15", "SubjectLine": "B", "OpenRate": 18.5},
+        {"IssueDate": "2025-05-01", "SubjectLine": "C", "OpenRate": 17.9},
+    ]
+    csv_path = write_csv(tmp_path, rows)
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = Exception("Timeout")
+    mock_get_client.return_value = mock_client
+
+    forecaster = MetricsForecaster()
+    with pytest.raises(RuntimeError) as exc:
+        forecaster.forecast(csv_path, ["Subj"])
+    assert "Groq API call failed" in str(exc.value)

--- a/tests/test_outline_architect.py
+++ b/tests/test_outline_architect.py
@@ -1,0 +1,57 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from src.agents.outline_architect import OutlineArchitect
+
+DUMMY_RESEARCH = (
+    "## Pain Points\n"
+    "- Low engagement on issue 1\n"
+    "- Subscribers dropping off after week 2\n\n"
+    "## Trending Articles\n"
+    "- Article A (https://a.com)\n"
+    "- Article B (https://b.com)"
+)
+
+DUMMY_ISSUE = "Topic: Habit Loops; Audience: 10k subscribers; Tone: minimal, direct."
+
+
+@patch("src.agents.outline_architect.get_groq_client")
+def test_generate_outlines_success(mock_get_client):
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+    dummy_md = (
+        "# Outline Option 1\n"
+        "## Section 1\n"
+        "Something\n"
+        "## Subject Line Candidates\n"
+        "- A\n- B\n- C\n\n"
+        "# Outline Option 2\n...\n"
+        "# Outline Option 3\n..."
+    )
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock(message=MagicMock(content=dummy_md))]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    arch = OutlineArchitect()
+    result = arch.generate_outlines(DUMMY_RESEARCH, DUMMY_ISSUE)
+
+    assert result.startswith("# Outline Option 1")
+    assert "# Outline Option 2" in result
+    assert "# Outline Option 3" in result
+
+
+@patch("src.agents.outline_architect.get_groq_client")
+def test_generate_outlines_empty_research(mock_get_client):
+    arch = OutlineArchitect()
+    with pytest.raises(ValueError):
+        arch.generate_outlines("", DUMMY_ISSUE)
+
+
+@patch("src.agents.outline_architect.get_groq_client")
+def test_generate_outlines_empty_issue(mock_get_client):
+    arch = OutlineArchitect()
+    with pytest.raises(ValueError):
+        arch.generate_outlines(DUMMY_RESEARCH, "")

--- a/tests/test_performance_analyst.py
+++ b/tests/test_performance_analyst.py
@@ -1,0 +1,86 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pandas as pd
+import pytest
+from unittest.mock import patch, MagicMock
+
+from src.agents.performance_analyst import PerformanceAnalyst
+
+DUMMY_FORECAST = "## Forecast\n- \"X\": Predicted open = 20%\n"
+
+
+def write_csv(path, rows):
+    pd.DataFrame(rows).to_csv(path, index=False)
+
+
+@patch("src.agents.performance_analyst.get_groq_client")
+def test_analyze_success(mock_get_client, tmp_path):
+    rows = [
+        {"IssueDate": "2025-06-01", "OpenRate": 19.0, "ClickRate": 3.5},
+        {"IssueDate": "2025-05-15", "OpenRate": 18.0, "ClickRate": 3.0},
+    ]
+    csv_path = tmp_path / "actuals.csv"
+    write_csv(csv_path, rows)
+
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+    dummy_output = (
+        "## Lessons Learned\n"
+        "- Forecast was within 1% of actual open rates.\n"
+        "- Click rates underperformed forecast; consider stronger CTAs.\n"
+        "- Consider A/B testing subject lines with < 2% variance.\n"
+    )
+    resp = MagicMock()
+    resp.choices = [MagicMock(message=MagicMock(content=dummy_output))]
+    mock_client.chat.completions.create.return_value = resp
+
+    analyst = PerformanceAnalyst()
+    result = analyst.analyze(DUMMY_FORECAST, str(csv_path))
+    assert "## Lessons Learned" in result
+    assert "Forecast was within" in result
+
+
+@patch("src.agents.performance_analyst.get_groq_client")
+def test_analyze_empty_forecast(mock_get_client, tmp_path):
+    mock_get_client.return_value = MagicMock()
+    analyst = PerformanceAnalyst()
+    with pytest.raises(ValueError):
+        analyst.analyze("", str(tmp_path / "x.csv"))
+
+
+@patch("src.agents.performance_analyst.get_groq_client")
+def test_analyze_csv_not_found(mock_get_client):
+    mock_get_client.return_value = MagicMock()
+    analyst = PerformanceAnalyst()
+    with pytest.raises(FileNotFoundError):
+        analyst.analyze(DUMMY_FORECAST, "no.csv")
+
+
+@patch("src.agents.performance_analyst.get_groq_client")
+def test_analyze_missing_columns(mock_get_client, tmp_path):
+    rows = [{"IssueDate": "2025-06-01", "OpenRate": 19.0}]
+    csv_path = tmp_path / "bad.csv"
+    write_csv(csv_path, rows)
+    mock_get_client.return_value = MagicMock()
+    analyst = PerformanceAnalyst()
+    with pytest.raises(ValueError):
+        analyst.analyze(DUMMY_FORECAST, str(csv_path))
+
+
+@patch("src.agents.performance_analyst.get_groq_client")
+def test_analyze_api_error(mock_get_client, tmp_path):
+    rows = [
+        {"IssueDate": "2025-06-01", "OpenRate": 19.0, "ClickRate": 3.5},
+        {"IssueDate": "2025-05-15", "OpenRate": 18.0, "ClickRate": 3.0},
+    ]
+    csv_path = tmp_path / "act.csv"
+    write_csv(csv_path, rows)
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = Exception("Timeout")
+    mock_get_client.return_value = mock_client
+
+    analyst = PerformanceAnalyst()
+    with pytest.raises(RuntimeError):
+        analyst.analyze(DUMMY_FORECAST, str(csv_path))


### PR DESCRIPTION
## Summary
- implement PerformanceAnalyst for post-send analytics
- expose `/api/analyze-performance` endpoint
- add frontend page and script for analysis
- include unit tests and documentation

## Testing
- `pytest --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_68430dcaca3c8327a57d3bfae8e52280